### PR TITLE
feat: implement useVoiceInput, useSpellingCheck, and useGameState hooks for web

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spelling Bee!</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "spelling-bee-web",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,9 @@
+import { BrowserRouter } from 'react-router-dom'
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <h1>Hello Spelling Bee</h1>
+    </BrowserRouter>
+  )
+}

--- a/web/src/data/words.json
+++ b/web/src/data/words.json
@@ -1,0 +1,20 @@
+{
+  "Easy": [
+    "cat", "dog", "sun", "hat", "run", "big", "red", "cup", "pen", "sit",
+    "hop", "map", "bug", "fan", "leg", "mud", "pig", "rod", "tip", "web",
+    "van", "wig", "fox", "jet", "box", "mix", "zip", "nut", "log", "fin"
+  ],
+  "Medium": [
+    "apple", "brush", "catch", "dance", "eagle", "fence", "giant", "house",
+    "image", "juice", "knife", "lemon", "magic", "night", "ocean", "piano",
+    "queen", "river", "snake", "table", "uncle", "voice", "witch", "xenon",
+    "yacht", "zebra", "cabin", "draft", "event", "flute"
+  ],
+  "Hard": [
+    "balloon", "captain", "diamond", "elegant", "feature", "glacier", "harmony",
+    "justify", "kitchen", "lantern", "monster", "numbers", "optimum", "pattern",
+    "qualify", "require", "shelter", "through", "uniform", "village", "whisper",
+    "younger", "zippers", "ancient", "balance", "cabinet", "darling", "excited",
+    "fashion", "general"
+  ]
+}

--- a/web/src/hooks/useGameState.ts
+++ b/web/src/hooks/useGameState.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback, useMemo } from 'react'
+import wordsData from '../data/words.json'
+
+export type Level = 'Easy' | 'Medium' | 'Hard'
+
+export interface GameState {
+  playerName: string
+  level: Level
+  score: number
+  lives: number
+  wordIndex: number
+  words: string[]
+  isGameOver: boolean
+}
+
+interface UseGameStateReturn extends GameState {
+  currentWord: string | null
+  totalWords: number
+  nextWord: () => void
+  addScore: (points: number) => void
+  loseLife: () => void
+  resetGame: (playerName?: string, level?: Level) => void
+  setPlayerName: (name: string) => void
+  setLevel: (level: Level) => void
+}
+
+const INITIAL_LIVES = 3
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const copy = [...arr]
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+  return copy
+}
+
+function getWordsForLevel(level: Level): string[] {
+  return shuffleArray(wordsData[level] ?? [])
+}
+
+export function useGameState(
+  initialPlayerName = '',
+  initialLevel: Level = 'Easy',
+): UseGameStateReturn {
+  const [playerName, setPlayerName] = useState(initialPlayerName)
+  const [level, setLevel] = useState<Level>(initialLevel)
+  const [score, setScore] = useState(0)
+  const [lives, setLives] = useState(INITIAL_LIVES)
+  const [wordIndex, setWordIndex] = useState(0)
+  const [words, setWords] = useState<string[]>(() => getWordsForLevel(initialLevel))
+
+  const isGameOver = lives <= 0 || wordIndex >= words.length
+
+  const currentWord = useMemo(() => {
+    if (wordIndex < words.length) return words[wordIndex]
+    return null
+  }, [words, wordIndex])
+
+  const nextWord = useCallback(() => {
+    setWordIndex((prev) => prev + 1)
+  }, [])
+
+  const addScore = useCallback((points: number) => {
+    setScore((prev) => prev + points)
+  }, [])
+
+  const loseLife = useCallback(() => {
+    setLives((prev) => Math.max(0, prev - 1))
+  }, [])
+
+  const resetGame = useCallback(
+    (newPlayerName?: string, newLevel?: Level) => {
+      const resolvedLevel = newLevel ?? level
+      setPlayerName(newPlayerName ?? playerName)
+      setLevel(resolvedLevel)
+      setScore(0)
+      setLives(INITIAL_LIVES)
+      setWordIndex(0)
+      setWords(getWordsForLevel(resolvedLevel))
+    },
+    [level, playerName],
+  )
+
+  // When level changes externally, reload the word list
+  const handleSetLevel = useCallback((newLevel: Level) => {
+    setLevel(newLevel)
+    setWords(getWordsForLevel(newLevel))
+    setWordIndex(0)
+    setScore(0)
+    setLives(INITIAL_LIVES)
+  }, [])
+
+  return {
+    playerName,
+    level,
+    score,
+    lives,
+    wordIndex,
+    words,
+    isGameOver,
+    currentWord,
+    totalWords: words.length,
+    nextWord,
+    addScore,
+    loseLife,
+    resetGame,
+    setPlayerName,
+    setLevel: handleSetLevel,
+  }
+}

--- a/web/src/hooks/useSpellingCheck.ts
+++ b/web/src/hooks/useSpellingCheck.ts
@@ -1,0 +1,152 @@
+/**
+ * Maps phonetic letter names (as a speech recogniser might hear them) to their
+ * corresponding alphabet letter.  Covers the most common English pronunciations
+ * plus NATO phonetic alphabet.
+ */
+const PHONETIC_TO_LETTER: Record<string, string> = {
+  // Standard letter-name pronunciations
+  ay: 'a',
+  bee: 'b',
+  be: 'b',
+  sea: 'c',
+  see: 'c',
+  dee: 'd',
+  ee: 'e',
+  ef: 'f',
+  eff: 'f',
+  gee: 'g',
+  ji: 'g',
+  aitch: 'h',
+  haitch: 'h',
+  eye: 'i',
+  jay: 'j',
+  kay: 'k',
+  el: 'l',
+  em: 'm',
+  en: 'n',
+  oh: 'o',
+  owe: 'o',
+  pee: 'p',
+  pe: 'p',
+  cue: 'q',
+  queue: 'q',
+  ar: 'r',
+  are: 'r',
+  es: 's',
+  ess: 's',
+  tee: 't',
+  te: 't',
+  you: 'u',
+  yoo: 'u',
+  vee: 'v',
+  ve: 'v',
+  'double you': 'w',
+  'double-you': 'w',
+  doubleyou: 'w',
+  ex: 'x',
+  why: 'y',
+  wi: 'y',
+  zee: 'z',
+  zed: 'z',
+  // NATO phonetic alphabet
+  alpha: 'a',
+  bravo: 'b',
+  charlie: 'c',
+  delta: 'd',
+  echo: 'e',
+  foxtrot: 'f',
+  golf: 'g',
+  hotel: 'h',
+  india: 'i',
+  juliet: 'j',
+  kilo: 'k',
+  lima: 'l',
+  mike: 'm',
+  november: 'n',
+  oscar: 'o',
+  papa: 'p',
+  quebec: 'q',
+  romeo: 'r',
+  sierra: 's',
+  tango: 't',
+  uniform: 'u',
+  victor: 'v',
+  whiskey: 'w',
+  xray: 'x',
+  'x-ray': 'x',
+  yankee: 'y',
+  zulu: 'z',
+}
+
+/**
+ * Normalise a raw speech transcript into a plain lowercase string of letters
+ * that can be compared against the target word.
+ *
+ * Handles three input formats:
+ *   1. Letter-by-letter:  "C A T"          → "cat"
+ *   2. Phonetic names:    "see ay tee"      → "cat"
+ *   3. Full word:         "cat"             → "cat"
+ */
+function normaliseTranscript(transcript: string): string {
+  const lower = transcript.toLowerCase().trim()
+
+  // Remove punctuation that speech recognition occasionally inserts
+  const cleaned = lower.replace(/[.,!?;:'"]/g, '').trim()
+
+  const tokens = cleaned.split(/\s+/)
+
+  // 1. Letter-by-letter: every token is a single alphabet character
+  if (tokens.every((t) => t.length === 1 && /^[a-z]$/.test(t))) {
+    return tokens.join('')
+  }
+
+  // 2. Phonetic names: try to map every token to a letter
+  //    Handle "double you" which spans two tokens
+  const letters: string[] = []
+  let i = 0
+  while (i < tokens.length) {
+    // Check for two-token phonetic ("double you")
+    if (i + 1 < tokens.length) {
+      const twoToken = `${tokens[i]} ${tokens[i + 1]}`
+      if (PHONETIC_TO_LETTER[twoToken]) {
+        letters.push(PHONETIC_TO_LETTER[twoToken])
+        i += 2
+        continue
+      }
+    }
+
+    const mapped = PHONETIC_TO_LETTER[tokens[i]]
+    if (mapped) {
+      letters.push(mapped)
+    } else {
+      // At least one token isn't a phonetic name → fall through to full-word
+      letters.length = 0
+      break
+    }
+    i++
+  }
+
+  if (letters.length > 0) {
+    return letters.join('')
+  }
+
+  // 3. Full word: return cleaned string (no spaces)
+  return cleaned.replace(/\s+/g, '')
+}
+
+/**
+ * Check whether a voice transcript matches the target word.
+ *
+ * @param transcript - Raw string from SpeechRecognition
+ * @param targetWord - The word the player is supposed to spell
+ * @returns true if the normalised transcript matches the target word
+ */
+export function useSpellingCheck() {
+  function checkSpelling(transcript: string, targetWord: string): boolean {
+    const normalised = normaliseTranscript(transcript)
+    const target = targetWord.toLowerCase().trim()
+    return normalised === target
+  }
+
+  return { checkSpelling, normaliseTranscript }
+}

--- a/web/src/hooks/useVoiceInput.ts
+++ b/web/src/hooks/useVoiceInput.ts
@@ -1,0 +1,105 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+
+// Extend Window to include webkit prefixed SpeechRecognition (Safari/iOS)
+declare global {
+  interface Window {
+    SpeechRecognition: typeof SpeechRecognition
+    webkitSpeechRecognition: typeof SpeechRecognition
+  }
+}
+
+interface UseVoiceInputReturn {
+  startListening: () => void
+  stopListening: () => void
+  transcript: string
+  isListening: boolean
+  isSupported: boolean
+  error: string | null
+  resetTranscript: () => void
+}
+
+export function useVoiceInput(): UseVoiceInputReturn {
+  const [transcript, setTranscript] = useState('')
+  const [isListening, setIsListening] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+
+  const SpeechRecognitionClass =
+    window.SpeechRecognition || window.webkitSpeechRecognition
+
+  const isSupported = !!SpeechRecognitionClass
+
+  useEffect(() => {
+    if (!isSupported) return
+
+    const recognition = new SpeechRecognitionClass()
+    recognition.continuous = false
+    recognition.interimResults = false
+    recognition.lang = 'en-US'
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const result = event.results[event.results.length - 1]
+      if (result.isFinal) {
+        setTranscript(result[0].transcript.trim())
+      }
+    }
+
+    recognition.onend = () => {
+      setIsListening(false)
+    }
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      setIsListening(false)
+      switch (event.error) {
+        case 'not-allowed':
+          setError('Microphone permission denied. Please allow mic access and try again.')
+          break
+        case 'no-speech':
+          setError('No speech detected. Please try again.')
+          break
+        case 'network':
+          setError('Network error during speech recognition. Please check your connection.')
+          break
+        default:
+          setError(`Speech recognition error: ${event.error}`)
+      }
+    }
+
+    recognitionRef.current = recognition
+
+    return () => {
+      recognition.abort()
+    }
+  }, [isSupported, SpeechRecognitionClass])
+
+  const startListening = useCallback(() => {
+    if (!isSupported) {
+      setError('Speech recognition is not supported in this browser.')
+      return
+    }
+    setError(null)
+    setTranscript('')
+    setIsListening(true)
+    recognitionRef.current?.start()
+  }, [isSupported])
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop()
+    setIsListening(false)
+  }, [])
+
+  const resetTranscript = useCallback(() => {
+    setTranscript('')
+    setError(null)
+  }, [])
+
+  return {
+    startListening,
+    stopListening,
+    transcript,
+    isListening,
+    isSupported,
+    error,
+    resetTranscript,
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
Ports the spelling-bee game logic from React Native to the browser:
- useVoiceInput: wraps Web Speech API (SpeechRecognition / webkitSpeechRecognition)
  with startListening/stopListening, transcript, isListening, isSupported, and
  graceful error handling for mic-denied / no-speech / network errors.
- useSpellingCheck: normalises voice input in three formats (letter-by-letter
  "C A T", phonetic "see ay tee", full word "cat") using a phonetic→letter map
  that covers standard English names and the NATO phonetic alphabet.
- useGameState: manages score, lives (3), wordIndex, level, and playerName;
  words are loaded from words.json and shuffled per level; exposes nextWord,
  addScore, loseLife, and resetGame actions.
Also scaffolds the /web project structure (Vite + React + TypeScript) with
package.json, tsconfig.json, vite.config.ts, index.html, and words.json.

https://claude.ai/code/session_01TKHSQraNVFZpUACCQ7Fw46